### PR TITLE
feat(etl): end-to-end Spark analytics pipeline — fix data ingestion and wire financial analytics layer

### DIFF
--- a/etl_service/pipelines/spark_pipeline.py
+++ b/etl_service/pipelines/spark_pipeline.py
@@ -14,12 +14,28 @@ Usage:
 
 import argparse
 import logging
+import os
 import sys
 import time
 
 from pyspark.sql import SparkSession
 
 from etl_service.src.adapters.spark_companies_builder import SparkCompaniesBuilder
+from etl_service.src.adapters.spark_financials_reader import SparkFinancialsReader
+from etl_service.src.adapters.aml_performance_utils import (
+    apply_subsector_rolling_performance,
+    enrich_companies_with_subsector_risk,
+)
+
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+logger = logging.getLogger(__name__)
+
+DB_HOST = os.getenv("DB_HOST", "localhost")
+DB_NAME = os.getenv("DB_NAME", "investment_analysis")
+DB_USER = os.getenv("DB_USER", "postgres")
+DB_PASS = os.getenv("DB_PASS", "postgres")
+JDBC_URL = f"jdbc:postgresql://{DB_HOST}:5432/{DB_NAME}"
+DB_PROPERTIES = {"user": DB_USER, "password": DB_PASS, "driver": "org.postgresql.Driver"}
 
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
 logger = logging.getLogger(__name__)
@@ -37,25 +53,50 @@ class SparkETLPipeline:
         logger.info(f"Spark session initialised in {spark_mode} mode")
 
     def run_companies_pipeline(self):
-        """End-to-end AML analytics demo using SparkCompaniesBuilder."""
+        """Two-stage AML analytics pipeline.
+
+        Stage 1 (always runs): Wikipedia CSV → SparkCompaniesBuilder → AML risk ranking.
+        Stage 2 (conditional): PostgreSQL → SparkFinancialsReader → rolling P/E window
+        and broadcast join via aml_performance_utils. Skipped gracefully if the DB has
+        not been populated by the standard pipeline yet.
+        """
         logger.info("Starting PySpark AML analytics pipeline...")
         start_time = time.time()
 
         try:
+            # ── Stage 1 ──────────────────────────────────────────────────────────
             builder = SparkCompaniesBuilder(self.spark)
             ranked_df = builder.run()  # extract → transform → rank → cache → run_analysis
 
-            # Join: enrich each company row with sector-level AML risk profile
             enriched_df = builder.join_sector_risk_profile(ranked_df)
-            logger.info("Company rows enriched with sector AML risk profile:")
+            logger.info("Stage 1: company rows enriched with sector AML risk profile:")
             enriched_df.show(5, truncate=False)
 
-            # Lag window: employee delta / velocity per sector
             trend_df = builder.get_sector_growth_trend(ranked_df)
-            logger.info("Sector growth trend (lag window):")
+            logger.info("Stage 1: sector growth trend (lag window):")
             trend_df.select(
                 "name", "sector", "year_founded", "number_of_employees", "employee_delta"
             ).show(10, truncate=False)
+
+            # ── Stage 2 ──────────────────────────────────────────────────────────
+            try:
+                reader = SparkFinancialsReader(self.spark, JDBC_URL, DB_PROPERTIES)
+                subsector_df = reader.get_subsector_financials()
+
+                rolling_df = apply_subsector_rolling_performance(subsector_df)
+                logger.info("Stage 2: rolling P/E window analytics:")
+                rolling_df.show(10, truncate=False)
+
+                enriched_financials = enrich_companies_with_subsector_risk(
+                    ranked_df, subsector_df
+                )
+                logger.info("Stage 2: companies enriched with sub-sector risk benchmarks:")
+                enriched_financials.show(5, truncate=False)
+
+            except Exception as e:
+                logger.warning(
+                    f"Stage 2 skipped — DB not populated or JDBC unavailable: {e}"
+                )
 
             logger.info(f"Pipeline completed in {time.time() - start_time:.2f}s")
 

--- a/etl_service/pipelines/standard_pipeline.py
+++ b/etl_service/pipelines/standard_pipeline.py
@@ -165,7 +165,7 @@ def main():
     if args.spark_mode:
         logger.info(f"Running in PySpark mode: {args.spark_mode}")
         try:
-            from etl_service.run_pipeline_spark import SparkETLPipeline
+            from etl_service.pipelines.spark_pipeline import SparkETLPipeline
             pipeline = SparkETLPipeline(spark_mode=args.spark_mode)
             
             if args.init_db:

--- a/etl_service/src/adapters/spark_companies_builder.py
+++ b/etl_service/src/adapters/spark_companies_builder.py
@@ -29,25 +29,12 @@ class SparkCompaniesBuilder:
     
     def __init__(self, spark: SparkSession):
         self.spark = spark
-        self.wiki_client = get_sp500_wiki_data()
-    
+        self._csv_path = get_sp500_wiki_data()  # triggers scrape if stale, returns filepath
+
     def extract_companies_data(self) -> DataFrame:
-        """Extract S&P 500 companies data from Wikipedia."""
-        logger.info("Extracting S&P 500 companies from Wikipedia...")
-        
-        try:
-            # Get raw data from Wikipedia client
-            companies_data = self.wiki_client.get_sp500_companies()
-            
-            # Convert to Spark DataFrame
-            df = self.spark.createDataFrame(companies_data)
-            
-            logger.info(f"Successfully extracted {df.count()} companies")
-            return df
-            
-        except Exception as e:
-            logger.error(f"Failed to extract companies data: {e}")
-            raise
+        """Load S&P 500 companies from the quarterly-suffixed Wikipedia CSV."""
+        logger.info(f"Loading S&P 500 companies from {self._csv_path}...")
+        return self.spark.read.csv(self._csv_path, header=True, inferSchema=True)
     
     def transform_companies_data(self, df: DataFrame) -> DataFrame:
         """Transform companies data using Spark operations."""

--- a/etl_service/src/adapters/spark_financials_reader.py
+++ b/etl_service/src/adapters/spark_financials_reader.py
@@ -1,0 +1,68 @@
+"""
+SparkFinancialsReader — reads quarterly_reports and prices_pe from PostgreSQL
+via JDBC and produces a DataFrame compatible with aml_performance_utils.
+
+Requires the standard pipeline to have populated the DB first.
+Stage 2 of the two-stage Spark analytics pipeline:
+
+  Stage 1: Wikipedia CSV → SparkCompaniesBuilder → AML risk ranking
+  Stage 2: PostgreSQL    → SparkFinancialsReader  → rolling P/E window + broadcast join
+"""
+
+import logging
+from pyspark.sql import SparkSession, DataFrame
+from pyspark.sql.functions import avg, col
+
+logger = logging.getLogger(__name__)
+
+
+class SparkFinancialsReader:
+    def __init__(self, spark: SparkSession, jdbc_url: str, db_properties: dict):
+        """
+        Args:
+            spark: active SparkSession
+            jdbc_url: e.g. "jdbc:postgresql://localhost:5432/investment_analysis"
+            db_properties: {"user": ..., "password": ..., "driver": "org.postgresql.Driver"}
+        """
+        self.spark = spark
+        self.jdbc_url = jdbc_url
+        self.db_properties = db_properties
+
+    def _read_table(self, table: str) -> DataFrame:
+        return self.spark.read.jdbc(
+            url=self.jdbc_url,
+            table=table,
+            properties=self.db_properties
+        )
+
+    def get_subsector_financials(self) -> DataFrame:
+        """
+        Join quarterly_reports → prices_pe → companies → sub_industries to produce
+        a DataFrame with the schema expected by aml_performance_utils:
+
+            sub_industry_gics | year | avg_price_earnings_ratio | avg_closing_price
+
+        This is the input surface for apply_subsector_rolling_performance() and
+        enrich_companies_with_subsector_risk().
+        """
+        logger.info("Reading financials tables from PostgreSQL via JDBC...")
+
+        prices = self._read_table("prices_pe")
+        quarterly = self._read_table("quarterly_reports")
+        companies = self._read_table("companies").select("id", "sub_industry_id")
+        sub_industries = self._read_table("sub_industries").select(
+            col("id").alias("sub_id"),
+            col("sub_industry_GICS").alias("sub_industry_gics")
+        )
+
+        joined = (
+            prices
+            .join(quarterly, on="company_id", how="inner")
+            .join(companies, prices["company_id"] == companies["id"], how="inner")
+            .join(sub_industries, col("sub_industry_id") == col("sub_id"), how="inner")
+        )
+
+        return joined.groupBy("sub_industry_gics", "year").agg(
+            avg("price_earnings_ratio").alias("avg_price_earnings_ratio"),
+            avg("closing_price").alias("avg_closing_price")
+        )

--- a/etl_service/src/adapters/wiki_page_client.py
+++ b/etl_service/src/adapters/wiki_page_client.py
@@ -58,18 +58,17 @@ def get_sp500_wiki_data():
 
 def get_sp500_wiki_info():
     """Ingest S&P 500 company basic info from Wikipedia."""
-    url = 'https://en.wikipedia.org'
+    url = 'https://en.wikipedia.org/wiki/List_of_S%26P_500_companies'
     session = get_session_with_retries()
     response = session.get(url, headers=HEADERS, timeout=30)
     response.raise_for_status()
 
-    # Use StringIO to avoid FutureWarning from read_html
     tables = pd.read_html(StringIO(response.text))
     if not tables:
         raise ValueError("No tables found on Wikipedia S&P 500 page")
 
     sp500_df = tables[0]
-    # Rename 'Symbol' column to 'Ticker' for consistency across data sources
+    # Column is 'Symbol' on the S&P 500 page — rename to 'Ticker' for consistency
     return sp500_df.rename(columns={'Symbol': 'Ticker'})
 
 def include_employees_total(sp500_df):

--- a/etl_service/tests/test_spark_financials_reader.py
+++ b/etl_service/tests/test_spark_financials_reader.py
@@ -1,0 +1,98 @@
+"""
+Tests for SparkFinancialsReader.
+
+JDBC reads are replaced with spark.createDataFrame() so no live DB is required.
+"""
+import pytest
+from unittest.mock import patch, MagicMock
+from pyspark.sql import SparkSession, Row
+
+from etl_service.src.adapters.spark_financials_reader import SparkFinancialsReader
+
+
+@pytest.fixture(scope="module")
+def spark():
+    session = SparkSession.builder \
+        .master("local[1]") \
+        .appName("SparkFinancialsReaderTests") \
+        .config("spark.sql.adaptive.enabled", "false") \
+        .getOrCreate()
+    yield session
+    session.stop()
+
+
+def _make_reader(spark):
+    return SparkFinancialsReader(
+        spark,
+        jdbc_url="jdbc:postgresql://localhost:5432/test",
+        db_properties={"user": "test", "password": "test", "driver": "org.postgresql.Driver"},
+    )
+
+
+def test_get_subsector_financials_schema(spark):
+    """Output DataFrame must have the four columns aml_performance_utils expects."""
+    prices = spark.createDataFrame([
+        Row(company_id=1, price_earnings_ratio=20.0, closing_price=150.0, year=2023),
+        Row(company_id=2, price_earnings_ratio=30.0, closing_price=200.0, year=2023),
+    ])
+    quarterly = spark.createDataFrame([
+        Row(company_id=1, revenue=1000000),
+        Row(company_id=2, revenue=2000000),
+    ])
+    companies = spark.createDataFrame([
+        Row(id=1, sub_industry_id=10),
+        Row(id=2, sub_industry_id=10),
+    ])
+    sub_industries = spark.createDataFrame([
+        Row(id=10, sub_industry_GICS="Application Software"),
+    ])
+
+    reader = _make_reader(spark)
+
+    # Patch _read_table to return our mock DataFrames
+    table_map = {
+        "prices_pe": prices,
+        "quarterly_reports": quarterly,
+        "companies": companies,
+        "sub_industries": sub_industries,
+    }
+    with patch.object(reader, "_read_table", side_effect=lambda t: table_map[t]):
+        result = reader.get_subsector_financials()
+
+    cols = set(result.columns)
+    assert {"sub_industry_gics", "year", "avg_price_earnings_ratio", "avg_closing_price"} <= cols
+
+
+def test_get_subsector_financials_aggregation(spark):
+    """avg_price_earnings_ratio should be the mean across companies in the sub-sector."""
+    prices = spark.createDataFrame([
+        Row(company_id=1, price_earnings_ratio=20.0, closing_price=100.0, year=2023),
+        Row(company_id=2, price_earnings_ratio=40.0, closing_price=200.0, year=2023),
+    ])
+    quarterly = spark.createDataFrame([
+        Row(company_id=1, revenue=1000000),
+        Row(company_id=2, revenue=2000000),
+    ])
+    companies = spark.createDataFrame([
+        Row(id=1, sub_industry_id=10),
+        Row(id=2, sub_industry_id=10),
+    ])
+    sub_industries = spark.createDataFrame([
+        Row(id=10, sub_industry_GICS="Application Software"),
+    ])
+
+    reader = _make_reader(spark)
+    table_map = {
+        "prices_pe": prices,
+        "quarterly_reports": quarterly,
+        "companies": companies,
+        "sub_industries": sub_industries,
+    }
+    with patch.object(reader, "_read_table", side_effect=lambda t: table_map[t]):
+        result = reader.get_subsector_financials().collect()
+
+    assert len(result) == 1
+    row = result[0]
+    assert row["sub_industry_gics"] == "Application Software"
+    assert row["avg_price_earnings_ratio"] == pytest.approx(30.0)
+    assert row["avg_closing_price"] == pytest.approx(150.0)


### PR DESCRIPTION
## What this PR does

Four commits that take the PySpark analytics layer from test-only to a runnable
end-to-end pipeline against real data.

## Commits

### 1. fix(etl): correct Wikipedia S&P 500 URL

`get_sp500_wiki_info()` was fetching `https://en.wikipedia.org` (the homepage)
instead of `/wiki/List_of_S%26P_500_companies`. The result was a 2-line CSV
containing Wikipedia's featured picture caption — no ticker data. Fixed to the
correct URL; 503 companies now ingested and verified (AAPL, IBM confirmed present).

### 2. fix(etl): load wiki CSV via spark.read.csv in SparkCompaniesBuilder

`__init__` assigned the filepath string returned by `get_sp500_wiki_data()` to
`self.wiki_client`, then called `self.wiki_client.get_sp500_companies()` —
an `AttributeError` at runtime. Replaced with `spark.read.csv(path)`, which is
the correct Spark ingestion pattern for a local file source.

### 3. feat(etl): add SparkFinancialsReader — JDBC reader wiring DB tables to aml_performance_utils

New module `src/adapters/spark_financials_reader.py`. Reads `quarterly_reports`,
`prices_pe`, `companies`, and `sub_industries` from PostgreSQL via
`spark.read.jdbc()` and produces a `sub_industry_gics / year` aggregation with
`avg_price_earnings_ratio` and `avg_closing_price` — the schema expected by
`apply_subsector_rolling_performance()` and `enrich_companies_with_subsector_risk()`
in `aml_performance_utils.py`.

### 4. feat(etl): wire aml_performance_utils into spark_pipeline; fix stale import path

`spark_pipeline.py` now runs two sequential analytics passes:

**Pass 1 — company universe (always runs):**
Wikipedia CSV → SparkCompaniesBuilder → AML risk ranking by sector,
employee-delta velocity (lag window), sector risk profile join

**Pass 2 — financial analytics (runs only if DB is populated):**
PostgreSQL → SparkFinancialsReader → rolling 2-year P/E window by sub-industry
(`apply_subsector_rolling_performance`) and sub-sector risk enrichment via
broadcast join (`enrich_companies_with_subsector_risk`).
Skips gracefully if JDBC is unavailable — the standard Airflow/FMP pipeline
must run first to populate `quarterly_reports` and `prices_pe`.

The two passes are decoupled by design: Pass 1 requires only a network connection
to Wikipedia; Pass 2 requires a populated DB. This matches the expected execution
order in both local dev (no live API keys) and production environments.

`standard_pipeline.py`: fix broken import — `SparkETLPipeline` was referenced at
`etl_service.run_pipeline_spark` (non-existent path); corrected to
`etl_service.pipelines.spark_pipeline`.

## Test coverage

```
tests/test_wiki_page_client.py           1 test  — filepath resolution
tests/test_spark_companies_builder.py    5 tests — window functions, AML flagging, join, lag
tests/test_aml_performance_utils.py      2 tests — rolling window, broadcast join
tests/test_spark_financials_reader.py    2 tests — JDBC reads mocked, schema + aggregation
────────────────────────────────────────────────
10/10 passing
```

No live database or API keys required to run the test suite.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added financial data enrichment to company profiles, including performance metrics and risk assessment by sector

* **Improvements**
  * Pipeline gracefully continues if financial database is unavailable instead of failing
  * Flexible environment-based configuration for database connections
  * Optimized data source resolution for company list accuracy

<!-- end of auto-generated comment: release notes by coderabbit.ai -->